### PR TITLE
Reading default host as set by phabricator.uri or default config option

### DIFF
--- a/phabricator/__init__.py
+++ b/phabricator/__init__.py
@@ -178,6 +178,12 @@ class Result(object):
     def __getattr__(self, key):
         return self.response[key]
 
+    def __getstate__(self):
+        return self.response
+
+    def __setstate__(self, state):
+        self.response = state
+
     def __len__(self):
         return len(self.response.keys())
 


### PR DESCRIPTION
As it stands, the default selected by keys()[0] will be arbitrary if there is more than one host
