### PR TITLE
Seems some installs namespace custom methods

### DIFF
--- a/phabricator/__init__.py
+++ b/phabricator/__init__.py
@@ -107,7 +107,7 @@ def parse_interfaces(interfaces):
     parsed_interfaces = defaultdict(dict)
 
     for m, d in interfaces.iteritems():
-        app, func = m.split('.')
+        app, func = m.split('.', 1)
 
         method = parsed_interfaces[app][func] = {}
 


### PR DESCRIPTION
Since namespacing isn't something done anywhere in vanilla phabricator, trust those users can use the less convenient method access too