### PR TITLE
Support new style token-based authentication

### DIFF
--- a/phabricator/__init__.py
+++ b/phabricator/__init__.py
@@ -309,15 +309,19 @@ class Phabricator(Resource):
     }
 
     def __init__(self, username=None, certificate=None, host=None,
-            timeout=5, response_format='json', **kwargs):
+            timeout=5, response_format='json', token=None, **kwargs):
 
         # Set values in ~/.arcrc as defaults
         if ARCRC:
             self.host = host if host else ARCRC['hosts'].keys()[0]
-            self.username = username if username else ARCRC['hosts'][self.host]['user']
-            self.certificate = certificate if certificate else ARCRC['hosts'][self.host]['cert']
+            if token or ARCRC['hosts'][self.host].has_key('token'):
+                self.token = token if token else ARCRC['hosts'][self.host]['token']
+            else:
+                self.username = username if username else ARCRC['hosts'][self.host]['user']
+                self.certificate = certificate if certificate else ARCRC['hosts'][self.host]['cert']
         else:
             self.host = host
+            self.token = token
             self.username = username
             self.certificate = certificate
 
@@ -334,6 +338,12 @@ class Phabricator(Resource):
         raise SyntaxError('You cannot call the Conduit API without a resource.')
 
     def connect(self):
+        if self.token:
+            self.conduit = {
+                'token': self.token
+            }
+            return
+
         auth = Resource(api=self, method='conduit', endpoint='connect')
 
         response = auth(user=self.username, host=self.host,

--- a/phabricator/tests.py
+++ b/phabricator/tests.py
@@ -9,6 +9,9 @@ RESPONSES = {
     'maniphest.find': '{"result":{"PHID-TASK-4cgpskv6zzys6rp5rvrc":{"id":"722","phid":"PHID-TASK-4cgpskv6zzys6rp5rvrc","authorPHID":"PHID-USER-5022a9389121884ab9db","ownerPHID":"PHID-USER-5022a9389121884ab9db","ccPHIDs":["PHID-USER-5022a9389121884ab9db","PHID-USER-ba8aeea1b3fe2853d6bb"],"status":"3","priority":"Needs Triage","title":"Relations should be two-way","description":"When adding a differential revision you can specify Maniphest Tickets to add the relation. However, this doesnt add the relation from the ticket -> the differently.(This was added via the commit message)","projectPHIDs":["PHID-PROJ-358dbc2e601f7e619232","PHID-PROJ-f58a9ac58c333f106a69"],"uri":"https:\/\/secure.phabricator.com\/T722","auxiliary":[],"objectName":"T722","dateCreated":"1325553508","dateModified":"1325618490"}},"error_code":null,"error_info":null}'
 }
 
+# Protect against local user's .arcrc interference.
+phabricator.ARCRC = {}
+
 class PhabricatorTest(unittest.TestCase):
     def setUp(self):
         self.api = phabricator.Phabricator(username='test', certificate='test', host='http://localhost')


### PR DESCRIPTION
Phabricator has moved on from the clunky user+certificate-based authentication
scheme into one that provides the API user with a single token that can be
used directly. This change adds support for that and prefers it when available.

Fixes #22.