### PR TITLE
Python 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.egg-info
 build/
 dist/
+.tox/
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+install: "pip install ."
+script: nosetests
+

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 python-phabricator
 ==================
 
+.. image:: https://travis-ci.org/MediaMiser/python-phabricator.png?branch=master
+	:target: https://travis-ci.org/MediaMiser/python-phabricator
+
 Installation
 ------------
 

--- a/phabricator/__init__.py
+++ b/phabricator/__init__.py
@@ -292,7 +292,7 @@ class Resource(object):
         # TODO: Use HTTP "method" from interfaces.json
         conn.request('POST', path, body, headers)
         response = conn.getresponse()
-        data = self._parse_response(response.read())
+        data = self._parse_response(response.read().decode('utf-8'))
 
         return Result(data['result'])
 

--- a/phabricator/__init__.py
+++ b/phabricator/__init__.py
@@ -8,6 +8,11 @@ python-phabricator
 For more endpoints, see https://secure.phabricator.com/conduit/
 
 """
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from past.builtins import basestring
+from builtins import object
 try:
     __version__ = __import__('pkg_resources') \
         .get_distribution('phabricator').version
@@ -16,14 +21,13 @@ except:
 
 import copy
 import hashlib
-import httplib
+import http.client
 import json
 import os.path
 import re
 import socket
 import time
-import urllib
-import urlparse
+from urllib import request, parse, error
 
 from collections import defaultdict
 
@@ -121,7 +125,7 @@ def parse_interfaces(interfaces):
     """
     parsed_interfaces = defaultdict(dict)
 
-    for m, d in interfaces.iteritems():
+    for m, d in interfaces.items():
         app, func = m.split('.', 1)
 
         method = parsed_interfaces[app][func] = {}
@@ -133,7 +137,7 @@ def parse_interfaces(interfaces):
         method['optional'] = {}
         method['required'] = {}
 
-        for name, type_info in dict(d['params']).iteritems():
+        for name, type_info in dict(d['params']).items():
             # Usually in the format: <optionality> <param_type>
             info_pieces = type_info.split(' ', 1)
 
@@ -200,17 +204,17 @@ class Result(object):
         self.response = state
 
     def __len__(self):
-        return len(self.response.keys())
+        return len(list(self.response.keys()))
 
     def keys(self):
-        return self.response.keys()
+        return list(self.response.keys())
 
     def iteritems(self):
-        for k, v in self.response.iteritems():
+        for k, v in self.response.items():
             yield k, v
 
     def itervalues(self):
-        for v in self.response.itervalues():
+        for v in self.response.values():
             yield v
 
 
@@ -243,7 +247,7 @@ class Resource(object):
             return isinstance(key, target)
 
         for k in resource.get('required', []):
-            if k not in [x.split(':')[0] for x in kwargs.keys()]:
+            if k not in [x.split(':')[0] for x in list(kwargs.keys())]:
                 raise ValueError('Missing required argument: %s' % k)
             if isinstance(kwargs.get(k), list) and not isinstance(resource['required'][k], list):
                 raise ValueError('Wrong argument type: %s is not a list' % k)
@@ -267,11 +271,11 @@ class Resource(object):
             self.api.connect()
             kwargs['__conduit__'] = self.api.conduit
 
-        url = urlparse.urlparse(self.api.host)
+        url = parse.urlparse(self.api.host)
         if url.scheme == 'https':
-            conn = httplib.HTTPSConnection(url.netloc, timeout=self.api.timeout)
+            conn = http.client.HTTPSConnection(url.netloc, timeout=self.api.timeout)
         else:
-            conn = httplib.HTTPConnection(url.netloc, timeout=self.api.timeout)
+            conn = http.client.HTTPConnection(url.netloc, timeout=self.api.timeout)
 
         path = url.path + '%s.%s' % (self.method, self.endpoint)
 
@@ -280,7 +284,7 @@ class Resource(object):
             'Content-Type': 'application/x-www-form-urlencoded'
         }
 
-        body = urllib.urlencode({
+        body = parse.urlencode({
             "params": json.dumps(kwargs),
             "output": self.api.response_format
         })
@@ -313,8 +317,8 @@ class Phabricator(Resource):
 
         # Set values in ~/.arcrc as defaults
         if ARCRC:
-            self.host = host if host else ARCRC['hosts'].keys()[0]
-            if token or ARCRC['hosts'][self.host].has_key('token'):
+            self.host = host if host else list(ARCRC['hosts'].keys())[0]
+            if token or 'token' in ARCRC['hosts'][self.host]:
                 self.token = token if token else ARCRC['hosts'][self.host]['token']
             else:
                 self.username = username if username else ARCRC['hosts'][self.host]['user']
@@ -355,7 +359,7 @@ class Phabricator(Resource):
         }
 
     def generate_hash(self, token):
-        return hashlib.sha1(token + self.api.certificate).hexdigest()
+        return hashlib.sha1((token + self.api.certificate).encode('utf-8')).hexdigest()
 
     def update_interfaces(self):
         query = Resource(api=self, method='conduit', endpoint='query')

--- a/phabricator/tests.py
+++ b/phabricator/tests.py
@@ -2,7 +2,7 @@ from future import standard_library
 standard_library.install_aliases()
 import phabricator
 import unittest
-from io import StringIO
+from io import StringIO, BytesIO
 from mock import patch, Mock
 
 RESPONSES = {
@@ -31,7 +31,7 @@ class PhabricatorTest(unittest.TestCase):
     @patch('phabricator.http.client.HTTPConnection')
     def test_connect(self, mock_connection):
         mock = mock_connection.return_value = Mock()
-        mock.getresponse.return_value = StringIO(RESPONSES['conduit.connect'])
+        mock.getresponse.return_value = BytesIO(RESPONSES['conduit.connect'].encode('utf-8'))
 
         api = phabricator.Phabricator(username='test', certificate='test', host='http://localhost')
         api.connect()
@@ -41,7 +41,7 @@ class PhabricatorTest(unittest.TestCase):
     @patch('phabricator.http.client.HTTPConnection')
     def test_user_whoami(self, mock_connection):
         mock = mock_connection.return_value = Mock()
-        mock.getresponse.return_value = StringIO(RESPONSES['user.whoami'])
+        mock.getresponse.return_value = BytesIO(RESPONSES['user.whoami'].encode('utf-8'))
 
         api = phabricator.Phabricator(username='test', certificate='test', host='http://localhost')
         api.conduit = True
@@ -51,7 +51,7 @@ class PhabricatorTest(unittest.TestCase):
     @patch('phabricator.http.client.HTTPConnection')
     def test_maniphest_find(self, mock_connection):
         mock = mock_connection.return_value = Mock()
-        mock.getresponse.return_value = StringIO(RESPONSES['maniphest.find'])
+        mock.getresponse.return_value = BytesIO(RESPONSES['maniphest.find'].encode('utf-8'))
 
         api = phabricator.Phabricator(username='test', certificate='test', host='http://localhost')
         api.conduit = True

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='phabricator',
-    version='0.4.0',
+    version='0.4.1',
     author='DISQUS',
     author_email='opensource@disqus.com',
     url='http://github.com/disqus/python-phabricator',
@@ -12,7 +12,7 @@ setup(
     packages=find_packages(),
     zip_safe=False,
     test_suite='nose.collector',
-    install_requires=[''],
+    install_requires=['future'],
     tests_require=['nose', 'unittest2', 'mock'],
     include_package_data=True,
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist =
+    py27
+    py33
+    py34
+    py35
+[testenv]
+deps =
+    nose
+    unittest2
+    mock
+commands =
+    nosetests


### PR DESCRIPTION
Added support for a few versions of Python 3 (3.3–3.5) while retaining Python 2.7 support using the future package.

Tested by adding a Travis CI configuration that tests installation and running tests for Python 2.7 and 3.3–3.5 (with visual output of the build status on the README page rendered in GitHub).