### PR TITLE
Fix regular expressions that cause type parsing to fail

### DIFF
--- a/phabricator/__init__.py
+++ b/phabricator/__init__.py
@@ -103,9 +103,9 @@ PARAM_TYPE_MAP = {
     'type': string_types,
 }
 
-TYPE_INFO_COMMENT_RE = re.compile(r'\s*\([^)]+\)\s*|,.+$')
+TYPE_INFO_COMMENT_RE = re.compile(r'\s*\([^)]+\)\s*$')
 TYPE_INFO_SPLITTER_RE = re.compile(r'(\w+(?:<.+>)?)(?:\s+|$)')
-TYPE_INFO_RE = re.compile(r'(\w+)(<[^>]+>)?(?:\s+|$)')
+TYPE_INFO_RE = re.compile(r'<?(\w+)(<[^>]+>>?)?(?:.+|$)')
 
 
 def map_param_type(param_type):
@@ -127,7 +127,7 @@ def map_param_type(param_type):
         # Handle list of pairs: "optional list<pair<callsign, path>>"
         sub_match = TYPE_INFO_RE.match(sub_type)
         if sub_match:
-            sub_type = sub_match.group(0).lower()
+            sub_type = sub_match.group(1).lower()
 
         return [PARAM_TYPE_MAP.setdefault(sub_type, string_types)]
 

--- a/phabricator/tests/test_phabricator.py
+++ b/phabricator/tests/test_phabricator.py
@@ -139,6 +139,18 @@ class PhabricatorTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.api.differential.find(query='1', guids='1')
 
+    def test_map_param_type(self):
+        uint = 'uint'
+        self.assertEqual(phabricator.map_param_type(uint), int) 
+
+        list_bool = 'list<bool>'
+        self.assertEqual(phabricator.map_param_type(list_bool), [bool]) 
+
+        list_pair = 'list<pair<callsign, path>>'
+        self.assertEqual(phabricator.map_param_type(list_pair), [tuple]) 
+
+        complex_list_pair = 'list<pair<string-constant<"gtcm">, string>>'
+        self.assertEqual(phabricator.map_param_type(complex_list_pair), [tuple])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The two regular expressions below were causing type detection to fail, which resulted in more complex types to end up as simply "string". This would cause validation errors, rendering perfectly formed requests unusable. This patch fixes those problems.