### PR TITLE
Add proxy support for http and https

### DIFF
--- a/phabricator/__init__.py
+++ b/phabricator/__init__.py
@@ -288,9 +288,21 @@ class Resource(object):
 
         url = urlparse.urlparse(self.api.host)
         if url.scheme == 'https':
-            conn = httplib.HTTPSConnection(url.netloc, timeout=self.api.timeout)
+            proxy = os.environ.get("https_proxy")
+            if proxy:
+                proxyurl = urlparse.urlparse(proxy)
+                conn = httplib.HTTPSConnection(proxyurl.netloc, timeout=self.api.timeout)
+                conn.set_tunnel(url.netloc);
+            else:
+                conn = httplib.HTTPSConnection(url.netloc, timeout=self.api.timeout)
         else:
-            conn = httplib.HTTPConnection(url.netloc, timeout=self.api.timeout)
+            proxy = os.environ.get("http_proxy")
+            if proxy:
+                proxyurl = urlparse.urlparse(proxy)
+                conn = httplib.HTTPConnection(proxyurl.netloc, timeout=self.api.timeout)
+                conn.set_tunnel(url.netloc);
+            else:
+                conn = httplib.HTTPConnection(url.netloc, timeout=self.api.timeout)
 
         path = url.path + '%s.%s' % (self.method, self.endpoint)
 


### PR DESCRIPTION
If http_proxy or https_proxy environment variable is defined,
feed its content to python's http_client library.
In a shell script, it is possible to assign the proxy :
$ export http_proxy="http://192.168.0.17:3128".
$ export https_proxy="http://192.168.0.17:3128".

Signed-off-by: Frédéric Dalleau <frederic.dalleau@collabora.com>