### PR TITLE
deprecated parameters are now set to optional

### DIFF
--- a/phabricator/__init__.py
+++ b/phabricator/__init__.py
@@ -170,6 +170,8 @@ def parse_interfaces(interfaces):
                     param_type = 'string'
                 elif info_piece == 'nonempty':
                     optionality = 'required'
+                elif info_piece == 'deprecated':
+                    optionality = 'optional'
                 else:
                     param_type = info_piece
 


### PR DESCRIPTION
parameters that have been deprecated were left with the default setting of `'required'`

(such as `parentRevisionID` in `differential.creatediff`)

added a check for deprecated parameters to set them to `'optional'`