### PR TITLE
loading json interfaces via pkgutils

### DIFF
--- a/phabricator/__init__.py
+++ b/phabricator/__init__.py
@@ -37,7 +37,8 @@ CURRENT_DIR = os.getcwd()
 
 
 # Default Phabricator interfaces
-INTERFACES = json.loads(pkgutil.get_data(__name__, 'interfaces.json'))
+json_data = pkgutil.get_data(__name__, 'interfaces.json').decode('utf-8')
+INTERFACES = json.loads(json_data)
 
 
 # Load arc config

--- a/phabricator/__init__.py
+++ b/phabricator/__init__.py
@@ -22,6 +22,7 @@ import os.path
 import re
 import socket
 import time
+import pkgutil
 
 from ._compat import (
     MutableMapping, iteritems, string_types, httplib, urlparse, urlencode,
@@ -36,9 +37,7 @@ CURRENT_DIR = os.getcwd()
 
 
 # Default Phabricator interfaces
-INTERFACES = {}
-with open(os.path.join(os.path.dirname(__file__), 'interfaces.json')) as fobj:
-    INTERFACES = json.load(fobj)
+INTERFACES = json.loads(pkgutil.get_data(__name__, 'interfaces.json'))
 
 
 # Load arc config

--- a/phabricator/__init__.py
+++ b/phabricator/__init__.py
@@ -37,8 +37,7 @@ CURRENT_DIR = os.getcwd()
 
 
 # Default Phabricator interfaces
-json_data = pkgutil.get_data(__name__, 'interfaces.json').decode('utf-8')
-INTERFACES = json.loads(json_data)
+INTERFACES = json.loads(pkgutil.get_data(__name__, 'interfaces.json').decode('utf-8'))
 
 
 # Load arc config

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if sys.version_info[:2] <= (3, 3):
 
 setup(
     name='phabricator',
-    version='0.7.1_tm',
+    version='0.7.0',
     author='Disqus',
     author_email='opensource@disqus.com',
     url='http://github.com/disqus/python-phabricator',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if sys.version_info[:2] <= (3, 3):
 
 setup(
     name='phabricator',
-    version='0.7.0',
+    version='0.7.1_tm',
     author='Disqus',
     author_email='opensource@disqus.com',
     url='http://github.com/disqus/python-phabricator',


### PR DESCRIPTION
The file `interfaces.json` is loaded with the customary pkgutil.
Accessing via path.dirname causes path problem when `python-phabricator` is containerised in a .pex file.

Thanks for the help!