### PR TITLE
Make sure connection is closed cleanly after use

### DIFF
--- a/phabricator/__init__.py
+++ b/phabricator/__init__.py
@@ -312,11 +312,13 @@ class Resource(object):
 
         # Make sure we got a 2xx response indicating success
         if not response.status >= 200 or not response.status < 300:
+            conn.close()
             raise httplib.HTTPException(
                 'Bad response status: {0}'.format(response.status)
             )
 
         response_data = response.read()
+        conn.close()
         if isinstance(response_data, str):
             response = response_data
         else:

--- a/phabricator/tests/test_phabricator.py
+++ b/phabricator/tests/test_phabricator.py
@@ -56,6 +56,7 @@ class PhabricatorTest(unittest.TestCase):
             RESPONSES['conduit.connect']
         )
         mock_obj.getresponse.return_value.status = 200
+        mock_obj.close = mock.Mock()
 
         api = phabricator.Phabricator(
             username='test',
@@ -67,6 +68,7 @@ class PhabricatorTest(unittest.TestCase):
         keys = api._conduit.keys()
         self.assertIn('sessionKey', keys)
         self.assertIn('connectionID', keys)
+        mock_obj.close.assert_called_once_with()
 
     @mock.patch('phabricator.httplib.HTTPConnection')
     def test_user_whoami(self, mock_connection):
@@ -108,6 +110,7 @@ class PhabricatorTest(unittest.TestCase):
         mock_obj = mock_connection.return_value = mock.Mock()
         mock_obj.getresponse.return_value = mock.Mock()
         mock_obj.getresponse.return_value.status = 400
+        mock_obj.close = mock.Mock()
 
         api = phabricator.Phabricator(
                 username='test',
@@ -118,6 +121,7 @@ class PhabricatorTest(unittest.TestCase):
 
         with self.assertRaises(phabricator.httplib.HTTPException):
             api.user.whoami()
+        mock_obj.close.assert_called_once_with()
 
     @mock.patch('phabricator.httplib.HTTPConnection')
     def test_maniphest_find(self, mock_connection):


### PR DESCRIPTION
Although the socket typically ends up closed before cleanup, this is not always the case, resulting in warnings like `<...>/phabricator/__init__.py:248: ResourceWarning: unclosed <ssl.SSLSocket fd=3, ...>`. This patch fixes that behavior to ensure the connection socket is closed before garbage collection begins.