### PR TITLE
Prevent Phabricator.token from shadowing the conduit token API

### DIFF
--- a/phabricator/__init__.py
+++ b/phabricator/__init__.py
@@ -357,9 +357,9 @@ class Phabricator(Resource):
             raise ConfigurationError("No host found or provided.")
 
         current_host_config = defined_hosts.get(self.host, {})
-        self.token = token if token else current_host_config.get('token')
+        self.conduit_token = token if token else current_host_config.get('token')
 
-        if self.token is None:
+        if self.conduit_token is None:
             self.username = username if username else current_host_config.get('user')
             self.certificate = certificate if certificate else current_host_config.get('cert')
 
@@ -376,9 +376,9 @@ class Phabricator(Resource):
         raise SyntaxError('You cannot call the Conduit API without a resource.')
 
     def connect(self):
-        if self.token:
+        if self.conduit_token:
             self._conduit = {
-                'token': self.token
+                'token': self.conduit_token
             }
             return
 

--- a/phabricator/tests/test_phabricator.py
+++ b/phabricator/tests/test_phabricator.py
@@ -176,5 +176,13 @@ class PhabricatorTest(unittest.TestCase):
         complex_list_pair = 'list<pair<string-constant<"gtcm">, string>>'
         self.assertEqual(phabricator.map_param_type(complex_list_pair), [tuple])
 
+    def test_endpoint_shadowing(self):
+        shadowed_endpoints = [e for e in self.api.interface.keys() if e in self.api.__dict__]
+        self.assertEqual(
+            shadowed_endpoints,
+            [],
+            "The following endpoints are shadowed: {}".format(shadowed_endpoints)
+        )
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Conduit token endpoints (`token.*`) cannot be called because `token` is
alreay in the `Phabricator.__dict__` and shadows the interface methods.
This can be prevented by renaming `token` into `conduit_token`.

A test case is added to prevent shadowing to occur again.