### PR TITLE
Replace httplib with requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
 - '2.7'
 - '3.5'
-install: pip install .
+install: pip install .[tests]
 script: python -m phabricator.tests.test_phabricator
 deploy:
   provider: pypi

--- a/phabricator/__init__.py
+++ b/phabricator/__init__.py
@@ -23,9 +23,10 @@ import re
 import socket
 import pkgutil
 import time
+import requests
 
 from ._compat import (
-    MutableMapping, iteritems, string_types, httplib, urlparse, urlencode,
+    MutableMapping, iteritems, string_types, urlencode,
 )
 
 
@@ -290,43 +291,28 @@ class Resource(object):
             self.api.connect()
             kwargs['__conduit__'] = self.api._conduit
 
-        url = urlparse.urlparse(self.api.host)
-        if url.scheme == 'https':
-            conn = httplib.HTTPSConnection(url.netloc, timeout=self.api.timeout)
-        else:
-            conn = httplib.HTTPConnection(url.netloc, timeout=self.api.timeout)
-
-        path = url.path + '%s.%s' % (self.method, self.endpoint)
 
         headers = {
             'User-Agent': 'python-phabricator/%s' % str(self.api.clientVersion),
             'Content-Type': 'application/x-www-form-urlencoded'
         }
 
-        body = urlencode({
+        body = {
             "params": json.dumps(kwargs),
             "output": self.api.response_format
-        })
+        }
 
         # TODO: Use HTTP "method" from interfaces.json
-        conn.request('POST', path, body, headers)
-        response = conn.getresponse()
+        path = '%s%s.%s' % (self.api.host, self.method, self.endpoint)
+        response = requests.post(path, data=body, headers=headers, timeout=self.api.timeout)
 
         # Make sure we got a 2xx response indicating success
-        if not response.status >= 200 or not response.status < 300:
-            conn.close()
-            raise httplib.HTTPException(
-                'Bad response status: {0}'.format(response.status)
+        if not response.status_code >= 200 or not response.status_code < 300:
+            raise requests.exceptions.HTTPError(
+                'Bad response status: {0}'.format(response.status_code)
             )
 
-        response_data = response.read()
-        conn.close()
-        if isinstance(response_data, str):
-            response = response_data
-        else:
-            response = response_data.decode("utf-8")
-
-        data = self._parse_response(response)
+        data = self._parse_response(response.text)
 
         return Result(data['result'])
 

--- a/phabricator/_compat.py
+++ b/phabricator/_compat.py
@@ -8,16 +8,6 @@ except ImportError:
     from collections import MutableMapping
 
 try:
-    import httplib
-except ImportError:
-    import http.client as httplib
-
-try:
-    import urlparse
-except ImportError:
-    import urllib.parse as urlparse
-
-try:
     from urllib import urlencode
 except ImportError:
     from urllib.parse import urlencode

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 
 from setuptools import setup, find_packages
 
-tests_requires = []
+tests_requires = ['responses>=0.12']
 
 if sys.version_info[:2] < (2, 7):
     tests_requires.append('unittest2')
@@ -21,8 +21,11 @@ setup(
     description='Phabricator API Bindings',
     packages=find_packages(),
     zip_safe=False,
+    install_requires=['requests>=2.22'],
     test_suite='phabricator.tests.test_phabricator',
-    tests_require=tests_requires,
+    extras_require={
+        'tests': tests_requires,
+    },
     include_package_data=True,
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
Not sure if you want to integrate this change upstream, but I thought I would share this diff. In this diff I replaced `htplib` with `requests`. My motivation behind this was so that I could use `requests_cache` (afaik nothing similar exists for `httlib`) to cache the responses from Phabricator. Also, nowadays `requests` seems to be the go-to library.

Note that I didn't port the tests, thus the tests will fail.