### PR TITLE
resolve conflict between Resource .interface attr and Almanac interface endpoints

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.8.1
+
+* Fixed bug where built-in interface dict overwrote `interface` methods from Almanac (`interface.search`, `interface.edit`). The `Resource` attribute `interface` is renamed `_interface`.
+
 0.8.0
 
 * Switch to using requests

--- a/phabricator/__init__.py
+++ b/phabricator/__init__.py
@@ -224,7 +224,7 @@ class Result(MutableMapping):
 class Resource(object):
     def __init__(self, api, interface=None, endpoint=None, method=None, nested=False):
         self.api = api
-        self.interface = interface or copy.deepcopy(parse_interfaces(INTERFACES))
+        self._interface = interface or copy.deepcopy(parse_interfaces(INTERFACES))
         self.endpoint = endpoint
         self.method = method
         self.nested = nested
@@ -232,7 +232,7 @@ class Resource(object):
     def __getattr__(self, attr):
         if attr in getattr(self, '__dict__'):
             return getattr(self, attr)
-        interface = self.interface
+        interface = self._interface
         if self.nested:
             attr = "%s.%s" % (self.endpoint, attr)
         submethod_exists = False
@@ -254,7 +254,7 @@ class Resource(object):
 
     def _request(self, **kwargs):
         # Check for missing variables
-        resource = self.interface
+        resource = self._interface
 
         def validate_kwarg(key, target):
             # Always allow list
@@ -391,4 +391,4 @@ class Phabricator(Resource):
 
         interfaces = query()
 
-        self.interface = parse_interfaces(interfaces)
+        self._interface = parse_interfaces(interfaces)

--- a/phabricator/tests/test_phabricator.py
+++ b/phabricator/tests/test_phabricator.py
@@ -163,7 +163,7 @@ class PhabricatorTest(unittest.TestCase):
 
 
     def test_endpoint_shadowing(self):
-        shadowed_endpoints = [e for e in self.api.interface.keys() if e in self.api.__dict__]
+        shadowed_endpoints = [e for e in self.api._interface.keys() if e in self.api.__dict__]
         self.assertEqual(
             shadowed_endpoints,
             [],

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if sys.version_info[:2] <= (3, 3):
 
 setup(
     name='phabricator',
-    version='0.8.0',
+    version='0.8.1',
     author='Disqus',
     author_email='opensource@disqus.com',
     url='http://github.com/disqus/python-phabricator',


### PR DESCRIPTION
This should resolve #53

This may be a breaking change for some users.

There are now [Almanac endpoints](https://secure.phabricator.com/rPe502df509d5f8dd3106be50d7d83ac244ff96cb4) named `interface.edit` and `interface.search`. These conflict with the `Resource` attribute `interface`: https://github.com/disqus/python-phabricator/blob/master/phabricator/__init__.py#L227 which is always overwritten by a dict. I've renamed the attribute to `_interface`.

There are of course still possible future conflicts from the other Resource attributes.