### PR TITLE
Add default retry to phab APIs

### DIFF
--- a/phabricator/__init__.py
+++ b/phabricator/__init__.py
@@ -231,9 +231,9 @@ class Resource(object):
         self.nested = nested
         self.session = requests.Session()
         retry_strategy = Retry(
-            total=5,
-            status_forcelist=[429, 500, 502, 503, 504],
-            method_whitelist=["HEAD", "GET", "OPTIONS"]
+            total=3,
+            connect=3,
+            method_whitelist=["HEAD", "GET", "POST", "PATCH", "PUT", "OPTIONS"]
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
         self.session.mount("https://", adapter)

--- a/phabricator/__init__.py
+++ b/phabricator/__init__.py
@@ -230,12 +230,11 @@ class Resource(object):
         self.method = method
         self.nested = nested
         self.session = requests.Session()
-        retry_strategy = Retry(
+        adapter = HTTPAdapter(max_retries=Retry(
             total=3,
             connect=3,
-            method_whitelist=["HEAD", "GET", "POST", "PATCH", "PUT", "OPTIONS"]
-        )
-        adapter = HTTPAdapter(max_retries=retry_strategy)
+            allowed_methods=["HEAD", "GET", "POST", "PATCH", "PUT", "OPTIONS"]
+        ))
         self.session.mount("https://", adapter)
         self.session.mount("http://", adapter)
 


### PR DESCRIPTION
This change should harden these 

I am less familiar with python development, so please let me know if I am missing something here or if you would prefer not to bake in a little extra network hardening