### PR TITLE
Use method_whitelist for backwards compat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     description='Phabricator API Bindings',
     packages=find_packages(),
     zip_safe=False,
-    install_requires=['requests>=2.22'],
+    install_requires=['requests>=2.26'],
     test_suite='phabricator.tests.test_phabricator',
     extras_require={
         'tests': tests_requires,


### PR DESCRIPTION
Using old (now deprecated method_whitelist) to support older versions of based on dependency version ranges. If its possible to instead lock request/urllib version to higher, we can do that as well. Thanks and sorry for the churn!

@thekashifmalik 