### PR TITLE
Depend on urllib3 1.26+ for allowed_methods

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,10 @@ setup(
     description='Phabricator API Bindings',
     packages=find_packages(),
     zip_safe=False,
-    install_requires=['requests>=2.26'],
+    install_requires=[
+        'requests>=2.26',
+        'urllib3>=1.26',
+    ],
     test_suite='phabricator.tests.test_phabricator',
     extras_require={
         'tests': tests_requires,


### PR DESCRIPTION
Commit af4f8e9fedc77a62ee6aacb52a428e5c958beb51 "inline retry strat"
changed the 'method_whitelist' argument to the urllib3.util.Retry()
constructor to the new name 'allowed_methods'. This new name was
introduced in urllib3 1.26. But there was no direct or transitive
dependency on a new-enough version of urllib3.

Explicitly depend on a new-enough version of urllib3.
